### PR TITLE
add support for initramfs image

### DIFF
--- a/90_mender_boot_grub.cfg
+++ b/90_mender_boot_grub.cfg
@@ -21,6 +21,9 @@ else
 fi
 
 if linux (${mender_grub_storage_device},${ptable_type}${mender_boot_part})/boot/${kernel_imagetype} root=${mender_root} ${bootargs}; then
+    if test -e (${mender_grub_storage_device},${ptable_type}${mender_boot_part})/boot/${initrd_imagetype}; then
+        initrd (${mender_grub_storage_device},${ptable_type}${mender_boot_part})/boot/${initrd_imagetype}
+    fi
     maybe_pause "Pausing before booting."
     boot
 fi

--- a/mender_grubenv_defines.example
+++ b/mender_grubenv_defines.example
@@ -18,6 +18,8 @@ mender_grub_storage_device=hd0
 # Type of kernel (bzImage or zImage)
 kernel_imagetype=bzImage
 
+# Type of initrd image
+initrd_imagetype=initrd.img
 ################################################################################
 # Mandatory on ARM
 ################################################################################


### PR DESCRIPTION
Some systems boot using a initramfs image which does the
initial hardware setup. Add support for that in the Mender generated
grub.cfg

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>