### PR TITLE
add 'rootwait' to bootargs

### DIFF
--- a/02_root_bootargs_grub.cfg
+++ b/02_root_bootargs_grub.cfg
@@ -1,0 +1,1 @@
+set rootargs="rootwait"

--- a/10_bootargs_grub.cfg
+++ b/10_bootargs_grub.cfg
@@ -1,1 +1,1 @@
-set bootargs="${bootargs} ${console_bootargs}"
+set bootargs="${bootargs} ${console_bootargs} ${rootargs}"


### PR DESCRIPTION
Description of 'rootwait' in kernel docs,

    "Wait (indefinitely) for root device to show up.
     Useful for devices that are detected asynchronously
     (e.g. USB and MMC devices)."

The large majority of devices that we integrate use eMMC for storage
medium, and it is quite common to use a USB "live disk" for provisioning.

Without the 'rootwait' argument, mount of rootfs failes occasionally,
it is simple a race condition at boot and you are only lucky if it works
without it.

While at it I also seperate root related arguments in to a seperate
file (02_root_bootargs_grub.cfg).

Changelog: Title

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>