### PR TITLE
utilize regexp to dynamically set mender_grub_storage_device

### DIFF
--- a/05_mender_setup_grub.cfg
+++ b/05_mender_setup_grub.cfg
@@ -110,3 +110,5 @@ if [ "${upgrade_available}" = "1" ]; then
 
     mender_save_env
 fi
+
+regexp (.*),(.*) $root -s mender_grub_storage_device

--- a/mender_grubenv_defines.example
+++ b/mender_grubenv_defines.example
@@ -11,10 +11,6 @@ mender_rootfsb_part=3
 # Device file corresponding to the root filesystem partitions, without index.
 mender_kernel_root_base=/dev/mmcblk0p
 
-# Name of the storage device containing root filesystem partitions in GRUB
-# format.
-mender_grub_storage_device=hd0
-
 # Type of kernel (bzImage or zImage)
 kernel_imagetype=bzImage
 


### PR DESCRIPTION
I have not yet tested this, but wanted to get feedback on if we should do this change here as well.

Then we can drop the [this](https://github.com/mendersoftware/meta-mender/commit/d45f97ab00028652c6b89973118ab00c7b2a4bd6#diff-bc46dd47a4090aa122a21f594b972127R60) line in Yocto.

This feature is useful outside of Yocto so should try to integrate it here.