### PR TITLE
Remove kernel_devicetree.

### DIFF
--- a/90_mender_boot_grub.cfg
+++ b/90_mender_boot_grub.cfg
@@ -6,12 +6,6 @@ else
     ptable_type=msdos
 fi
 
-if test -n "${kernel_devicetree}"; then
-    if test -e (${mender_grub_storage_device},${ptable_type}${mender_boot_part})/boot/${kernel_devicetree}; then
-        devicetree (${mender_grub_storage_device},${ptable_type}${mender_boot_part})/boot/${kernel_devicetree}
-    fi
-fi
-
 if test -n "${mender_rootfsa_uuid}" -a test -n  "${mender_rootfsb_uuid}"; then
     if [ "${mender_boot_part}" = "${mender_rootfsa_part}" ]; then
         mender_root="PARTUUID=${mender_rootfsa_uuid}"

--- a/mender_grubenv_defines.example
+++ b/mender_grubenv_defines.example
@@ -20,10 +20,3 @@ kernel_imagetype=bzImage
 
 # Type of initrd image
 initrd_imagetype=initrd.img
-
-################################################################################
-# Mandatory on ARM
-################################################################################
-
-# Basename of DTB that should be loaded by the bootloader.
-kernel_devicetree=kernel.dtb


### PR DESCRIPTION
The only way to use GRUB 2.04 on ARM is via UEFI, and the
kernel_devicetree information is not used when loading via UEFI,
instead it is queried directly from the UEFI provider.

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>