### PR TITLE
fix: Fix grub.d integration which regressed after standalone fix.

### DIFF
--- a/04_mender_setup_env_functions_grub.cfg
+++ b/04_mender_setup_env_functions_grub.cfg
@@ -11,12 +11,28 @@
 # Note that Secure Boot and GRUB signatures are two different things, and here
 # we are talking about the latter.
 
-MENDER_ENV1=(${root})/grub-mender-grubenv/mender_grubenv1/env
-MENDER_LOCK1=(${root})/grub-mender-grubenv/mender_grubenv1/lock
-MENDER_ENV2=(${root})/grub-mender-grubenv/mender_grubenv2/env
-MENDER_LOCK2=(${root})/grub-mender-grubenv/mender_grubenv2/lock
+function mender_setup_env_location {
+    MENDER_ENV1=(${root})/grub-mender-grubenv/mender_grubenv1/env
+    MENDER_LOCK1=(${root})/grub-mender-grubenv/mender_grubenv1/lock
+    MENDER_ENV2=(${root})/grub-mender-grubenv/mender_grubenv2/env
+    MENDER_LOCK2=(${root})/grub-mender-grubenv/mender_grubenv2/lock
+
+    if [ ! -f ${MENDER_ENV1} -o ! -f ${MENDER_LOCK1} -o ! -f ${MENDER_ENV2} -o ! -f ${MENDER_LOCK2} ]; then
+        if [ "${check_signatures}" = "enforce" ]; then
+            echo "Signatures are enabled and the environment could not be found. Rebooting in 10 seconds..."
+            sleep 10
+            reboot
+        else
+            echo "The environment was not found. Tried to access ${MENDER_ENV1}. Continuing in 10 seconds..."
+            sleep 10
+            # Fallthrough and continue. Will most likely hit the "Environment is
+            # corrupt" section below.
+        fi
+    fi
+}
 
 function mender_check_and_restore_env {
+    mender_setup_env_location
     editing=invalid
     load_env --skip-sig --file ${MENDER_LOCK2} editing
     if [ "${editing}" != 0 ]; then
@@ -50,6 +66,7 @@ function mender_check_and_restore_env {
 
 function mender_save_env {
     # Save redundant environment.
+    mender_setup_env_location
     editing=1
     save_env --file ${MENDER_LOCK2} editing
     # See comment about "free form" variables near the top.
@@ -90,12 +107,18 @@ function mender_check_grubenv_valid {
 }
 
 function mender_load_env {
+    mender_setup_env_location
+
     # See comment about "free form" variables near the top.
     if [ "$check_signatures" = "enforce" ]; then
         load_env --skip-sig --file ${MENDER_ENV1} bootcount mender_boot_part upgrade_available
     else
         load_env --skip-sig --file ${MENDER_ENV1} bootcount mender_boot_part upgrade_available mender_systemd_machine_id
+        export mender_systemd_machine_id
     fi
+    export bootcount
+    export mender_boot_part
+    export upgrade_available
 
     if ! mender_check_grubenv_valid; then
         if [ "${check_signatures}" = "enforce" ]; then

--- a/grub.d/00_05_mender_setup_env_grub
+++ b/grub.d/00_05_mender_setup_env_grub
@@ -1,14 +1,10 @@
 if [ "$GRUB_MENDER_GRUBENV_CFG_GENERATION" != "true" ]; then
-    # First stage, before loading the rootfs specific grub-mender-grubenv.cfg.
+    # Only load the environment in the first stage, when we are executing from
+    # the boot partition. When executing from the root partition, we don't want
+    # to run this step.
     cat <<'EOF'
 mender_check_and_restore_env
 mender_load_env_with_rollback
-regexp (.*),(.*) $root -s mender_grub_storage_device
-EOF
-else
-    # Second stage, after loading the rootfs specific grub-mender-grubenv.cfg.
-    cat <<'EOF'
-mender_load_env
 regexp (.*),(.*) $root -s mender_grub_storage_device
 EOF
 fi


### PR DESCRIPTION
In 2ef6724268d024418, we changed the environment path slightly to
become compatible with standalone mode. This path is correct when
using grub.d integration as well, except for one detail: When using
grub.d integration, the script uses two passes (see
`grub.d/README-mender.md`). The path is only correct on the first
pass, because `root` is being adjusted from the boot partition to
the root partition in between those two passes.

The variables are used to load the environment, which we used to do
twice, but it's better to just load it once, and export the relevant
variables instead. So we now load it only during the first pass, and
then we don't use that path at all on the second pass, which both
fixes the issue, simplifies things, and may even make it a tiny bit
faster.

No changelog, since we haven't released the regression.

Changelog: None
Ticket: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>