### PR TITLE
Recompute sha256

### DIFF
--- a/grub-mender-grubenv-print
+++ b/grub-mender-grubenv-print
@@ -131,7 +131,8 @@ check_and_restore_env() {
         sync $ENV2
         ${GRUB_EDITENV} $LOCK2 create
         ${GRUB_EDITENV} $LOCK2 set editing=0
-        sync $LOCK2
+        sha256sum "$LOCK2" > "$LOCKSUM2"
+        sync "$LOCK2" "$LOCKSUM2"
         if ! ( cd `dirname $LOCKSUM2` && sha256sum -c $LOCKSUM2 > /dev/null ); then
             echo "Unable to restore environment 2." 1>&2
             exit 2
@@ -141,7 +142,8 @@ check_and_restore_env() {
         sync $ENV1
         ${GRUB_EDITENV} $LOCK1 create
         ${GRUB_EDITENV} $LOCK1 set editing=0
-        sync $LOCK1
+        sha256sum "$LOCK1" > "$LOCKSUM1"
+        sync "$LOCK1" "$LOCKSUM1"
         if ! ( cd `dirname $LOCKSUM1` && sha256sum -c $LOCKSUM1 > /dev/null ); then
             echo "Unable to restore environment 1." 1>&2
             exit 2

--- a/grub-mender-grubenv-print
+++ b/grub-mender-grubenv-print
@@ -109,10 +109,24 @@ make_evalable() {
     sed -e 's/'\''/'\'\\\\\'\''/g; s/\\\$/\\\$/g; s/=/='\''/; s/$/'\''/'
 }
 
+is_locksum_valid() {
+    local LOCKSUM="$1"
+
+    if ( cd "$(dirname $LOCKSUM)" && sha256sum -c "$LOCKSUM" > /dev/null ); then
+        echo "valid"
+    else
+        echo "invalid"
+    fi
+}
+
 check_and_restore_env() {
     # Check that both environments are valid, and if not, restore one using the
     # other.
-    if ! ( cd `dirname $LOCKSUM2` && sha256sum -c $LOCKSUM2 > /dev/null ); then
+    state_of_env1=$(is_locksum_valid "$LOCKSUM1")
+    state_of_env2=$(is_locksum_valid "$LOCKSUM2")
+
+    # Check if env1 is good and env2 bad
+    if [ "$state_of_env1" == "valid" ] && [ "$state_of_env2" == "invalid" ] ; then
         dd if=$ENV1 of=$ENV2 conv=notrunc > /dev/null 2>&1
         sync $ENV2
         ${GRUB_EDITENV} $LOCK2 create
@@ -122,7 +136,7 @@ check_and_restore_env() {
             echo "Unable to restore environment 2." 1>&2
             exit 2
         fi
-    elif ! ( cd `dirname $LOCKSUM1` && sha256sum -c $LOCKSUM1 > /dev/null ); then
+    elif [ "$state_of_env1" == "invalid" ] && [ "$state_of_env2" == "valid" ] ; then
         dd if=$ENV2 of=$ENV1 conv=notrunc > /dev/null 2>&1
         sync $ENV1
         ${GRUB_EDITENV} $LOCK1 create
@@ -132,6 +146,9 @@ check_and_restore_env() {
             echo "Unable to restore environment 1." 1>&2
             exit 2
         fi
+    elif [ "$state_of_env1" == "invalid" ] && [ "$state_of_env2" == "invalid" ] ; then
+        echo "Unable to restore environment both are corrupt." 1>&2
+        exit 2
     fi
 }
 


### PR DESCRIPTION
$> grub-editenv $LOCKFILE create
will differs compare to the actual file.

This will make the sha256sum always false.
Let's recompute the sha256sum after creating a new file

Actual: 
```
# GRUB Environment Block
editing=0
####################################...
```

New:
```
# GRUB Environment Block
# WARNING: Do not edit this file by tools other than grub-editenv!!!
editing=0
####################################...
```