### PR TITLE
fix: Make sure `mender_grub_storage_device` is exported to next script.

### DIFF
--- a/grub.d/00_05_mender_setup_env_grub
+++ b/grub.d/00_05_mender_setup_env_grub
@@ -6,5 +6,6 @@ if [ "$GRUB_MENDER_GRUBENV_CFG_GENERATION" != "true" ]; then
 mender_check_and_restore_env
 mender_load_env_with_rollback
 regexp (.*),(.*) $root -s mender_grub_storage_device
+export mender_grub_storage_device
 EOF
 fi


### PR DESCRIPTION
In grub.d mode (when integrated into the `/etc/grub.d` framework), the variable `mender_grub_storage_device` is set in the `grub.cfg` from the boot partition but is also used in the config from the root partition. Since it is never set there, the boot can fail.

Reported-by: @chgabriel79 on Github,
https://github.com/mendersoftware/grub-mender-grubenv/issues/33

Changelog: Fix boot failure because `mender_grub_storage_device` is not exported correctly.

Ticket: None