### PR TITLE
fix: Make sure `grub.d` integration works with partition UUIDs.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ build:grub-efi:
 
 test:
   stage: test
-  image: debian:10
+  image: debian:12
   variables:
     DEBIAN_FRONTEND: noninteractive
   before_script:
@@ -42,7 +42,7 @@ test:
 
 publish:s3:
   stage: publish
-  image: debian:buster
+  image: debian:12
   dependencies:
     - build:grub-efi
   before_script:

--- a/grub-efi/Dockerfile.aarch64
+++ b/grub-efi/Dockerfile.aarch64
@@ -1,7 +1,7 @@
-FROM debian:stretch
+FROM debian:12
 
 RUN apt-get update -q && \
-    apt-get install -qy crossbuild-essential-arm64 python wget bison flex
+    apt-get install -qy crossbuild-essential-arm64 python3 wget bison flex
 
 ARG GRUB_VERSION=none
 RUN if [ "$GRUB_VERSION" = none ]; then echo "GRUB_VERSION must be set!" 1>&2; exit 1; fi
@@ -11,7 +11,12 @@ RUN wget --progress=dot:mega ftp://ftp.gnu.org/gnu/grub/grub-${GRUB_VERSION}.tar
 
 WORKDIR grub-${GRUB_VERSION}
 
+# -Wno-array-bounds: GCC 12 generates warnings-as-errors which, according to
+# commit acffb81485e35e1f in GRUB, are false positives. They are in the process
+# of fixing it in GRUB 2.12, but it isn't released yet at the time of writing
+# this, so just disable this warning altogether.
 RUN ./configure \
+    CFLAGS=-Wno-array-bounds \
     --prefix=/install \
     --with-platform=efi \
     --host aarch64-linux-gnu

--- a/grub-efi/Dockerfile.arm
+++ b/grub-efi/Dockerfile.arm
@@ -1,7 +1,7 @@
-FROM debian:stretch
+FROM debian:12
 
 RUN apt-get update -q && \
-    apt-get install -qy crossbuild-essential-armhf python wget bison flex
+    apt-get install -qy crossbuild-essential-armhf python3 wget bison flex
 
 ARG GRUB_VERSION=none
 RUN if [ "$GRUB_VERSION" = none ]; then echo "GRUB_VERSION must be set!" 1>&2; exit 1; fi
@@ -11,7 +11,12 @@ RUN wget --progress=dot:mega ftp://ftp.gnu.org/gnu/grub/grub-${GRUB_VERSION}.tar
 
 WORKDIR grub-${GRUB_VERSION}
 
+# -Wno-array-bounds: GCC 12 generates warnings-as-errors which, according to
+# commit acffb81485e35e1f in GRUB, are false positives. They are in the process
+# of fixing it in GRUB 2.12, but it isn't released yet at the time of writing
+# this, so just disable this warning altogether.
 RUN ./configure \
+    CFLAGS=-Wno-array-bounds \
     --prefix=/install \
     --with-platform=efi \
     --host arm-linux-gnueabihf

--- a/grub-efi/Dockerfile.x86_64
+++ b/grub-efi/Dockerfile.x86_64
@@ -1,7 +1,7 @@
-FROM debian:stretch
+FROM debian:12
 
 RUN apt-get update -q && \
-    apt-get install -qy build-essential python wget bison flex
+    apt-get install -qy build-essential python3 wget bison flex
 
 ARG GRUB_VERSION=none
 RUN if [ "$GRUB_VERSION" = none ]; then echo "GRUB_VERSION must be set!" 1>&2; exit 1; fi
@@ -11,7 +11,12 @@ RUN wget --progress=dot:mega ftp://ftp.gnu.org/gnu/grub/grub-${GRUB_VERSION}.tar
 
 WORKDIR grub-${GRUB_VERSION}
 
+# -Wno-array-bounds: GCC 12 generates warnings-as-errors which, according to
+# commit acffb81485e35e1f in GRUB, are false positives. They are in the process
+# of fixing it in GRUB 2.12, but it isn't released yet at the time of writing
+# this, so just disable this warning altogether.
 RUN ./configure \
+    CFLAGS=-Wno-array-bounds \
     --prefix=/install \
     --with-platform=efi
 RUN make -j $(nproc)

--- a/grub-scripts/mender_offline_grub-probe_helper
+++ b/grub-scripts/mender_offline_grub-probe_helper
@@ -1,6 +1,15 @@
 #!/bin/sh
 
+set -e
+
+DEBUG=${DEBUG:-0}
+
 . /etc/default/grub.d/00_mender_grubenv_defines.cfg
+. /etc/default/grub.d/03_mender_compute_variables.cfg
+
+if [ "$DEBUG" = 1 ]; then
+    echo "Called with arguments $@" 1>&2
+fi
 
 # If there is a `--target=partmap` argument, return "gpt" for device names.
 if echo "$@" | egrep -q ' --target=partmap| -t partmap'; then
@@ -16,26 +25,24 @@ ROOT_PART_DEVICE=$("${mender_real_grub_probe}" -t device /)
 # Replace grub-probe arguments with loopback device names. Also replace
 # "part-*.fs" entries, which mender-convert uses.
 ARGS="$(echo "$@" | sed -E \
-    -e "s,${mender_kernel_root_base}1,${BOOT_PART_DEVICE},g" \
-    -e "s,${mender_kernel_root_base}${mender_rootfsa_part},${ROOT_PART_DEVICE},g" \
+    -e "s,${mender_full_boot_part}\\b,${BOOT_PART_DEVICE},g" \
+    -e "s,${mender_full_rootfsa_part}\\b,${ROOT_PART_DEVICE},g" \
     -e "s,[^ ]*part-1.fs,${BOOT_PART_DEVICE},g" \
     -e "s,[^ ]*part-2.fs,${ROOT_PART_DEVICE},g")"
 
-# If there is any occurrence of ${mender_kernel_root_base} still in the
-# arguments, it may be a partition we have not mounted, and therefore cannot
-# handle. Just fail the call, and the grub scripts should skip this partition.
-if echo "$ARGS" | fgrep ${mender_kernel_root_base} >/dev/null; then
-    echo "Cannot probe device in command line: $ARGS" 1>&2
-    exit 1
+# Replace grub-probe results with real device names.
+ret=0
+OUTPUT="$( "${mender_real_grub_probe}" $ARGS )" || ret=$?
+
+OUTPUT="$(echo "${OUTPUT}" | sed -E \
+    -e "s,${BOOT_PART_DEVICE}\\b,${mender_full_boot_part},g" \
+    -e "s,${ROOT_PART_DEVICE}\\b,${mender_full_rootfsa_part},g")"
+
+if [ "$DEBUG" = 1 ]; then
+    echo "Returning output: $OUTPUT" 1>&2
 fi
 
-TMP_RESULT=$(mktemp)
-# Replace grub-probe results with real device names.
-( "${mender_real_grub_probe}" $ARGS ; echo $? > $TMP_RESULT ) | sed -E \
-    -e "s,${BOOT_PART_DEVICE},${mender_kernel_root_base}1,g" \
-    -e "s,${ROOT_PART_DEVICE},${mender_kernel_root_base}${mender_rootfsa_part},g"
+echo "${OUTPUT}"
 
 # Return real exit code.
-ret=$(cat "$TMP_RESULT")
-rm -f "$TMP_RESULT"
 exit $ret

--- a/grub.d/00_03_mender_compute_variables.cfg
+++ b/grub.d/00_03_mender_compute_variables.cfg
@@ -1,0 +1,17 @@
+if [ -n "${mender_boot_uuid}" ]; then
+    mender_full_boot_part="/dev/disk/by-partuuid/${mender_boot_uuid}"
+else
+    mender_full_boot_part="${mender_kernel_root_base}${mender_boot_part}"
+fi
+
+if [ -n "${mender_rootfsa_uuid}" ]; then
+    mender_full_rootfsa_part="/dev/disk/by-partuuid/${mender_rootfsa_uuid}"
+else
+    mender_full_rootfsa_part="${mender_kernel_root_base}${mender_rootfsa_part}"
+fi
+
+if [ -n "${mender_rootfsb_uuid}" ]; then
+    mender_full_rootfsb_part="/dev/disk/by-partuuid/${mender_rootfsb_uuid}"
+else
+    mender_full_rootfsb_part="${mender_kernel_root_base}${mender_rootfsb_part}"
+fi

--- a/grub.d/default/03_mender_compute_variables.cfg
+++ b/grub.d/default/03_mender_compute_variables.cfg
@@ -1,0 +1,1 @@
+../00_03_mender_compute_variables.cfg

--- a/grub.d/default/mender-os-probe-skip.cfg
+++ b/grub.d/default/mender-os-probe-skip.cfg
@@ -2,8 +2,9 @@ pkgdatadir="${pkgdatadir:-/usr/share/grub}"
 
 . "${pkgdatadir}/grub-mkconfig_lib"
 . /etc/default/grub.d/00_mender_grubenv_defines.cfg
+. /etc/default/grub.d/03_mender_compute_variables.cfg
 
-for device in "${mender_kernel_root_base}${mender_rootfsa_part}" "${mender_kernel_root_base}${mender_rootfsb_part}"; do
+for device in "${mender_full_rootfsa_part}" "${mender_full_rootfsb_part}"; do
     if uuid="$(${grub_probe} --target=fs_uuid --device $device)"; then
         GRUB_OS_PROBER_SKIP_LIST="${GRUB_OS_PROBER_SKIP_LIST} ${uuid}@${device}"
     fi

--- a/grub.d/default/xx_mender_font_and_theme_handling.cfg
+++ b/grub.d/default/xx_mender_font_and_theme_handling.cfg
@@ -2,6 +2,7 @@ pkgdatadir="${pkgdatadir:-/usr/share/grub}"
 
 . "${pkgdatadir}/grub-mkconfig_lib"
 . /etc/default/grub.d/00_mender_grubenv_defines.cfg
+. /etc/default/grub.d/03_mender_compute_variables.cfg
 
 if [ -z "$GRUB_FONT" ]; then
     # Taken from 00_header in grub.d and tweaked:
@@ -19,8 +20,8 @@ if [ -z "$GRUB_FONT" ]; then
 fi
 
 if [ -n "$GRUB_FONT" ]; then
-    if [ "$(${grub_probe} --target=device "$GRUB_FONT")" = "${mender_kernel_root_base}${mender_rootfsa_part}" ] || \
-        [ "$(${grub_probe} --target=device "$GRUB_FONT")" = "${mender_kernel_root_base}${mender_rootfsb_part}" ]; then
+    if [ "$(${grub_probe} --target=device "$GRUB_FONT")" = "${mender_full_rootfsa_part}" ] || \
+        [ "$(${grub_probe} --target=device "$GRUB_FONT")" = "${mender_full_rootfsb_part}" ]; then
 
         mkdir -p /boot/grub/fonts
         cp -rf "$GRUB_FONT" "/boot/grub/fonts/"
@@ -29,8 +30,8 @@ if [ -n "$GRUB_FONT" ]; then
 fi
 
 if [ -n "$GRUB_THEME" ]; then
-    if [ "$(${grub_probe} --target=device "$GRUB_THEME")" = "${mender_kernel_root_base}${mender_rootfsa_part}" ] || \
-        [ "$(${grub_probe} --target=device "$GRUB_THEME")" = "${mender_kernel_root_base}${mender_rootfsb_part}" ]; then
+    if [ "$(${grub_probe} --target=device "$GRUB_THEME")" = "${mender_full_rootfsa_part}" ] || \
+        [ "$(${grub_probe} --target=device "$GRUB_THEME")" = "${mender_full_rootfsb_part}" ]; then
 
         mkdir -p /boot/grub/themes
         cp -rf "$GRUB_THEME" "/boot/grub/themes/"

--- a/tests/test_makefile.sh
+++ b/tests/test_makefile.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -92,11 +92,13 @@ boot/efi/grub-mender-grubenv/mender_grubenv2/env
 boot/efi/grub-mender-grubenv/mender_grubenv2/lock
 boot/efi/grub-mender-grubenv/mender_grubenv2/lock.sha256sum
 etc/default/grub.d/00_mender_grubenv_defines.cfg
+etc/default/grub.d/03_mender_compute_variables.cfg
 etc/default/grub.d/mender-export-grub_probe.cfg
 etc/default/grub.d/mender-os-probe-skip.cfg
 etc/default/grub.d/mender-root-device.cfg
 etc/default/grub.d/xx_mender_font_and_theme_handling.cfg
 etc/grub.d/00_00_mender_grubenv_defines
+etc/grub.d/00_03_mender_compute_variables
 etc/grub.d/00_04_mender_setup_env_functions_grub
 etc/grub.d/00_05_mender_setup_env_grub
 etc/grub.d/00_80_mender_choose_partitions_grub
@@ -134,11 +136,13 @@ make -s DESTDIR="$TMPDIR/install" DEFINES_FILE="$SRCDIR"/mender_grubenv_defines.
 find "$TMPDIR/install" -type f -o -type l | sed -e "s,^$TMPDIR/install/,," | sort > "$TMPDIR/actual.log"
 cat > "$TMPDIR/expected.log" <<EOF
 etc/default/grub.d/00_mender_grubenv_defines.cfg
+etc/default/grub.d/03_mender_compute_variables.cfg
 etc/default/grub.d/mender-export-grub_probe.cfg
 etc/default/grub.d/mender-os-probe-skip.cfg
 etc/default/grub.d/mender-root-device.cfg
 etc/default/grub.d/xx_mender_font_and_theme_handling.cfg
 etc/grub.d/00_00_mender_grubenv_defines
+etc/grub.d/00_03_mender_compute_variables
 etc/grub.d/00_04_mender_setup_env_functions_grub
 etc/grub.d/00_05_mender_setup_env_grub
 etc/grub.d/00_80_mender_choose_partitions_grub
@@ -236,11 +240,13 @@ boot/efi/grub-mender-grubenv/mender_grubenv2/env
 boot/efi/grub-mender-grubenv/mender_grubenv2/lock
 boot/efi/grub-mender-grubenv/mender_grubenv2/lock.sha256sum
 etc/default/grub.d/00_mender_grubenv_defines.cfg
+etc/default/grub.d/03_mender_compute_variables.cfg
 etc/default/grub.d/mender-export-grub_probe.cfg
 etc/default/grub.d/mender-os-probe-skip.cfg
 etc/default/grub.d/mender-root-device.cfg
 etc/default/grub.d/xx_mender_font_and_theme_handling.cfg
 etc/grub.d/00_00_mender_grubenv_defines
+etc/grub.d/00_03_mender_compute_variables
 etc/grub.d/00_04_mender_setup_env_functions_grub
 etc/grub.d/00_05_mender_setup_env_grub
 etc/grub.d/00_80_mender_choose_partitions_grub


### PR DESCRIPTION
There are a couple of things that need fixing here.

The main problem is that when using partition UUIDs, the `mender_kernel_root_base` doesn't exist. This is because partition UUIDs are independent of storage devices, so there is no logical value it can have. To fix it, we need to start referring to each partition individually instead. This requires support from mender-convert, which needs to start passing in the partition UUID of the boot partition.

Next, since we need to make a distinction between the UUID and non-UUID case, create a new `grub.d` script which computes the values centrally, so we don't need to sprinkle conditionals everywhere. Replace all existing `mender_kernel_root_base` references with these new references.

With `mender_kernel_root_base` gone, it's now harder to catch references to unknown partitions in the
`mender_offline_grub-probe_helper` script. We could fix this by doing individual parsing of each argument and look for unknown partitions, instead of parsing the whole set of arguments as one line. But that is a bigger change which I'm not going to do now. Instead, just remove the check, since it is only a safeguard, and does not affect the building of images which are already using valid configurations.

I also discovered that the matching expressions could sometimes match incorrectly because they were not anchored to a word boundary (so `loop11` could match `loop1` for instance). Added `\b` anchors to prevent that.

And finally I added a `DEBUG` variable which can be set for more information about what the `mender_offline_grub-probe_helper` is doing, which is helpful during debugging.

Changelog: Title
Ticket: MEN-6645