### PR TITLE
chore: Downgrade to Debian 10 (buster) as build platform again.

### DIFF
--- a/grub-efi/Dockerfile.aarch64
+++ b/grub-efi/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM debian:12
+FROM debian:10
 
 RUN apt-get update -q && \
     apt-get install -qy crossbuild-essential-arm64 python3 wget bison flex
@@ -11,12 +11,7 @@ RUN wget --progress=dot:mega ftp://ftp.gnu.org/gnu/grub/grub-${GRUB_VERSION}.tar
 
 WORKDIR grub-${GRUB_VERSION}
 
-# -Wno-array-bounds: GCC 12 generates warnings-as-errors which, according to
-# commit acffb81485e35e1f in GRUB, are false positives. They are in the process
-# of fixing it in GRUB 2.12, but it isn't released yet at the time of writing
-# this, so just disable this warning altogether.
 RUN ./configure \
-    CFLAGS=-Wno-array-bounds \
     --prefix=/install \
     --with-platform=efi \
     --host aarch64-linux-gnu

--- a/grub-efi/Dockerfile.arm
+++ b/grub-efi/Dockerfile.arm
@@ -1,4 +1,4 @@
-FROM debian:12
+FROM debian:10
 
 RUN apt-get update -q && \
     apt-get install -qy crossbuild-essential-armhf python3 wget bison flex
@@ -11,12 +11,7 @@ RUN wget --progress=dot:mega ftp://ftp.gnu.org/gnu/grub/grub-${GRUB_VERSION}.tar
 
 WORKDIR grub-${GRUB_VERSION}
 
-# -Wno-array-bounds: GCC 12 generates warnings-as-errors which, according to
-# commit acffb81485e35e1f in GRUB, are false positives. They are in the process
-# of fixing it in GRUB 2.12, but it isn't released yet at the time of writing
-# this, so just disable this warning altogether.
 RUN ./configure \
-    CFLAGS=-Wno-array-bounds \
     --prefix=/install \
     --with-platform=efi \
     --host arm-linux-gnueabihf

--- a/grub-efi/Dockerfile.x86_64
+++ b/grub-efi/Dockerfile.x86_64
@@ -1,4 +1,4 @@
-FROM debian:12
+FROM debian:10
 
 RUN apt-get update -q && \
     apt-get install -qy build-essential python3 wget bison flex
@@ -11,12 +11,7 @@ RUN wget --progress=dot:mega ftp://ftp.gnu.org/gnu/grub/grub-${GRUB_VERSION}.tar
 
 WORKDIR grub-${GRUB_VERSION}
 
-# -Wno-array-bounds: GCC 12 generates warnings-as-errors which, according to
-# commit acffb81485e35e1f in GRUB, are false positives. They are in the process
-# of fixing it in GRUB 2.12, but it isn't released yet at the time of writing
-# this, so just disable this warning altogether.
 RUN ./configure \
-    CFLAGS=-Wno-array-bounds \
     --prefix=/install \
     --with-platform=efi
 RUN make -j $(nproc)


### PR DESCRIPTION
This is because we need to build it on the lowest still-supported LTS, so that it runs on it and later versions.

Changelog: Drop support for Debian 9 (stretch).