### PR TITLE
MEN-7854: Update GRUB to version 2.12

### DIFF
--- a/grub-efi/grub.inc
+++ b/grub-efi/grub.inc
@@ -1,4 +1,4 @@
-GRUB_VERSION="2.04"
+GRUB_VERSION="2.12"
 
 GRUB_MODULES="boot linux ext2 fat serial part_msdos part_gpt normal \
               efi_gop iso9660 configfile search loadenv test \


### PR DESCRIPTION
From Yocto `scarthgap` release on, `mke2fs` enables the feature `metadata_csum_seed` by default, which is not understood in the previous GRUB version. See:
* Bug report: http://savannah.gnu.org/bugs/?56897
* Fix: https://git.savannah.gnu.org/cgit/grub.git/commit/?id=7fd5feff97c4b1f446f8fcf6d37aca0c64e7c763
* mke2fs release notes: https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/tree/doc/RelNotes/v1.47.0.txt

This change is done in the context of MEN-7854, were we identified that BBB, and any other board with ARMv7 using `meta-mender` will be using an old "pre-compiled" grub binary with this limitation.