### PR TITLE
fix: Integer comparisons for partitions

### DIFF
--- a/04_mender_setup_env_functions_grub.cfg
+++ b/04_mender_setup_env_functions_grub.cfg
@@ -91,7 +91,7 @@ function mender_save_env {
 }
 
 function mender_check_grubenv_valid {
-    if [ "${mender_boot_part}" != "${mender_rootfsa_part}" -a "${mender_boot_part}" != "${mender_rootfsb_part}" ]; then
+    if [ "${mender_boot_part}" -ne "${mender_rootfsa_part}" -a "${mender_boot_part}" -ne "${mender_rootfsb_part}" ]; then
         return 1
     fi
 
@@ -126,7 +126,7 @@ function mender_load_env {
             sleep 10
             reboot
         else
-            if [ "${mender_boot_part}" != "${mender_rootfsb_part}" ]; then
+            if [ "${mender_boot_part}" -ne "${mender_rootfsb_part}" ]; then
                 mender_boot_part="${mender_rootfsa_part}"
             fi
             echo "The environment is corrupt. Trying to boot from ${mender_kernel_root_base}${mender_boot_part} in 10 seconds, but this is not guaranteed to be a valid partition..."
@@ -142,7 +142,7 @@ function mender_load_env_with_rollback {
     if [ "${upgrade_available}" = "1" ]; then
         if [ "${bootcount}" != "0" ]; then
             echo "Rolling back..."
-            if [ "${mender_boot_part}" = "${mender_rootfsa_part}" ]; then
+            if [ "${mender_boot_part}" -eq "${mender_rootfsa_part}" ]; then
                 mender_boot_part="${mender_rootfsb_part}"
             else
                 mender_boot_part="${mender_rootfsa_part}"

--- a/80_mender_choose_partitions_grub.cfg
+++ b/80_mender_choose_partitions_grub.cfg
@@ -4,10 +4,10 @@
 # compatibility reasons. The rest of the variable names follow the latter
 # logic.
 
-if [ "${mender_boot_part}" = "${mender_rootfsa_part}" -a test -n "${mender_kernela_part}" ]; then
+if [ "${mender_boot_part}" -eq "${mender_rootfsa_part}" -a test -n "${mender_kernela_part}" ]; then
     mender_ptable_part=${mender_kernela_part}
     mender_kernel_path=""
-elif [ "${mender_boot_part}" = "${mender_rootfsb_part}" -a test -n "${mender_kernelb_part}" ]; then
+elif [ "${mender_boot_part}" -eq "${mender_rootfsb_part}" -a test -n "${mender_kernelb_part}" ]; then
     mender_ptable_part=${mender_kernelb_part}
     mender_kernel_path=""
 else
@@ -22,9 +22,9 @@ else
 fi
 
 if test -n "${mender_rootfsa_uuid}" -a test -n  "${mender_rootfsb_uuid}"; then
-    if [ "${mender_boot_part}" = "${mender_rootfsa_part}" ]; then
+    if [ "${mender_boot_part}" -eq "${mender_rootfsa_part}" ]; then
         mender_kernel_root="PARTUUID=${mender_rootfsa_uuid}"
-    elif [ "${mender_boot_part}" = "${mender_rootfsb_part}" ]; then
+    elif [ "${mender_boot_part}" -eq "${mender_rootfsb_part}" ]; then
         mender_kernel_root="PARTUUID=${mender_rootfsb_uuid}"
     fi
 else


### PR DESCRIPTION
Comparing numbers doesn't work the same way as comparing strings.

Changelog: Title
Ticket: ME-458
Signed-off-by: Nick Anderson <nick@cmdln.org>