### PR TITLE
ci: add qa-common retry and runner defaults

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,33 @@
 variables:
   S3_BUCKET_NAME: mender
+  DOCKER_HOST:
+    value: 'tcp://docker:2376'
+    description: "Required to run dind inside k8s runners with TLS"
+  DOCKER_TLS_CERTDIR:
+    value: '/certs'
+    description: "The cert dir inside the gitlab runner. Don't change this."
+  DOCKER_TLS_VERIFY:
+    value: 1
+    description: "Enable TLS verification for docker in dind"
+  DOCKER_CERT_PATH:
+    value: "$DOCKER_TLS_CERTDIR/client"
+    description: "Used for docker entrypoints. See https://gitlab.com/gitlab-org/gitlab-runner/-/issues/4125"
 
 include:
+  - project: Northern.tech/Mender/mendertesting
+    file:
+      - qa-common/runner.yml
+      - qa-common/retry.yml
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-commits-signoffs.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-license.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-github-status-updates.yml'
+
+default:
+  tags: !reference [.qa-common-default-runner, tags]
+  retry: !reference [.qa-common-default-retry, retry]
 
 stages:
   - test
@@ -34,6 +54,7 @@ test:
   variables:
     DEBIAN_FRONTEND: noninteractive
   before_script:
+    - !reference [.qa-common-network-apt-retry, before_script]
     - apt update && apt install -yy make
   script:
     - cp mender_grubenv_defines.example mender_grubenv_defines
@@ -46,6 +67,7 @@ publish:s3:
   dependencies:
     - build:grub-efi
   before_script:
+    - !reference [.qa-common-network-apt-retry, before_script]
     - apt update && apt install -yyq awscli git
   script:
     - ./grub-efi/prepare-output-folder-for-upload


### PR DESCRIPTION
Include qa-common/runner.yml and qa-common/retry.yml from mendertesting to apply a consistent .qa-common-default-runner tag and .qa-common-default-retry policy to all jobs pipeline-wide.

Add network probes (apt/go/git-clone) to jobs that perform network operations, so transient failures trigger a retry instead of a hard fail.

Ticket: QA-1490