### PR TITLE
ci: rename AWS credential variables to S3_UPLOAD_AWS_* prefix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,5 +74,5 @@ publish:s3:
     - aws s3 cp --recursive --acl public-read output/upload/ s3://$S3_BUCKET_NAME/grub-mender-grubenv/
   rules:
     - if: '$CI_COMMIT_REF_NAME =~ /^(master|[0-9]+\.[0-9]+\.x)$/'
-    - if: '$CI_COMMIT_REF_NAME !~ /^(master|[0-9]+\.[0-9]+\.x)$/ && $AWS_SECRET_ACCESS_KEY'
+    - if: '$CI_COMMIT_REF_NAME !~ /^(master|[0-9]+\.[0-9]+\.x)$/ && $S3_UPLOAD_AWS_SECRET_ACCESS_KEY'
       when: manual


### PR DESCRIPTION
## Summary

Renames \`\$AWS_SECRET_ACCESS_KEY\` to \`\$S3_UPLOAD_AWS_SECRET_ACCESS_KEY\` in the \`publish:s3\` job rule.

The Mender GitLab group variables \`AWS_ACCESS_KEY_ID\` and \`AWS_SECRET_ACCESS_KEY\` are being renamed to avoid leaking the \`jenkins-mender\` IAM user credentials into pipelines that use different AWS credentials (e.g. ECR logins), causing \`AccessDeniedException\` errors.

Ticket: QA-1648